### PR TITLE
Updating READMEs to reflect new location for ongoing development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # parcel_template_sandbox
 
+### This repo was the original testbed for template-based model steps, but development has moved to [ual/urbansim_parcel_bayarea](https://github.com/ual/urbansim_parcel_bayarea). The notebooks in this repo no longer run.
+
+-----
+
 Owner: Sam Maurer
 
 This repository is a testbed for parcel template development. The main content is this notebook:

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,1 @@
+### This repo was the original testbed for template-based model steps, but development has moved to [ual/urbansim_parcel_bayarea](https://github.com/ual/urbansim_parcel_bayarea). The notebooks in this repo no longer run.


### PR DESCRIPTION
This repo was the original testbed for template-based model steps, but development has moved to [ual/urbansim_parcel_bayarea](https://github.com/ual/urbansim_parcel_bayarea). The notebooks in this repo no longer run.

See https://github.com/ual/urbansim_parcel_bayarea/issues/27 for related discussion.